### PR TITLE
deps: Use `solana-test-validator` instead of `solana-validator`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ solana-sdk = "=1.11.5"
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
-solana-validator = "=1.11.5"
+solana-test-validator = "=1.11.5"
 
 [workspace]

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod test {
-    use {super::*, solana_validator::test_validator::*};
+    use {super::*, solana_test_validator::*};
 
     #[tokio::test]
     async fn test_ping() {


### PR DESCRIPTION
#### Problem

`solana-validator` is a big package, and potentially overkill for testing a CLI, especially since only the `test_validator` part is used, which is just a re-export of `solana-test-validator`.

#### Solution

Use `solana_test_validator::*` rather than `solana_validator::test_validator::*`